### PR TITLE
Fix overlapping pages by restoring __main__ guards

### DIFF
--- a/src/pages/Community.py
+++ b/src/pages/Community.py
@@ -309,5 +309,6 @@ def main():
         </div>
         """, unsafe_allow_html=True)
 
-# Execute the page logic when imported by Streamlit
-main()
+# Execute the page logic
+if __name__ == "__main__":
+    main()

--- a/src/pages/Expense_Calculator.py
+++ b/src/pages/Expense_Calculator.py
@@ -411,5 +411,6 @@ def main():
     </div>
     """, unsafe_allow_html=True)
 
-# Execute the page logic when imported by Streamlit
-main()
+# Execute the page logic
+if __name__ == "__main__":
+    main()

--- a/src/pages/Expense_Tracker.py
+++ b/src/pages/Expense_Tracker.py
@@ -247,5 +247,6 @@ def main():
             </div>
             """, unsafe_allow_html=True)
 
-# Execute the page logic when imported by Streamlit
-main()
+# Execute the page logic
+if __name__ == "__main__":
+    main()

--- a/src/pages/Job_Board.py
+++ b/src/pages/Job_Board.py
@@ -386,5 +386,6 @@ def main():
         </div>
         """, unsafe_allow_html=True)
 
-# Execute the page logic when imported by Streamlit
-main()
+# Execute the page logic
+if __name__ == "__main__":
+    main()

--- a/src/pages/Visa_Planner.py
+++ b/src/pages/Visa_Planner.py
@@ -362,5 +362,6 @@ def main():
         </div>
         """, unsafe_allow_html=True)
 
-# Execute the page logic when imported by Streamlit
-main()
+# Execute the page logic
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- prevent page modules from executing during import
- restore `if __name__ == '__main__'` guards for each page

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68407f9db354832bb65ecada1b7b5e97