### PR TITLE
Add user registration and hashed login

### DIFF
--- a/src/pages/Register.py
+++ b/src/pages/Register.py
@@ -1,0 +1,29 @@
+import streamlit as st
+from utils import load_css, initialize_session_state, register_user
+
+st.set_page_config(page_title="Register", page_icon="📝", layout="wide")
+
+load_css()
+initialize_session_state()
+
+st.markdown("## Create a New Account")
+
+with st.form("registration_form"):
+    username = st.text_input("Username")
+    password = st.text_input("Password", type="password")
+    confirm = st.text_input("Confirm Password", type="password")
+    submit = st.form_submit_button("Register")
+
+    if submit:
+        if not username or not password:
+            st.error("Username and password are required.")
+        elif password != confirm:
+            st.error("Passwords do not match.")
+        else:
+            success, msg = register_user(username, password)
+            if success:
+                st.success(msg)
+            else:
+                st.error(msg)
+
+st.link_button("Back to Login", "./")

--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -94,7 +94,8 @@ def login_page():
                     st.success("Login successful! Redirecting...")
                     st.rerun()
                 else:
-                    st.error("Invalid credentials. Use username: 'student', password: 'student'")
+                    st.error("Invalid username or password.")
+        st.page_link("pages/Register.py", label="Create a new account")
 
 def dashboard():
     st.markdown("""

--- a/src/users.json
+++ b/src/users.json
@@ -1,0 +1,6 @@
+[
+  {
+    "username": "student",
+    "password": "264c8c381bf16c982a4e59b0dd4c6f7808c51a05f64c35db42cc78a2a72875bb"
+  }
+]


### PR DESCRIPTION
## Summary
- store users in `src/users.json`
- implement hashed password authentication in `check_login`
- add `register_user` helper
- show login errors and link to registration
- create new `Register` page for creating accounts

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684093ac45b4832b8a3322e084a4bad6