### PR TITLE
Improve readability with expanders

### DIFF
--- a/src/pages/Expense_Tracker.py
+++ b/src/pages/Expense_Tracker.py
@@ -59,24 +59,24 @@ def main():
         <span>🎓 StudyAbroad Platform</span> > <span>Expense Tracker</span>
     </div>
     """, unsafe_allow_html=True)
-    
+
     # Back to dashboard button
     if st.button("← Back to Dashboard", key="back_to_dashboard"):
         st.switch_page("streamlit_app.py")
-    
+
     st.title("💰 Expense Tracker")
     st.markdown("Track your daily expenses and monitor your budget")
-    
+
     # Welcome message with progress
     if 'expenses' in st.session_state and len(st.session_state.expenses) > 0:
         total_expenses = len(st.session_state.expenses)
         st.success(f"Great job! You've tracked {total_expenses} expenses so far. Keep it up!")
     else:
         st.info("Welcome to your expense tracker! Start by adding your first expense below.")
-    
+
     # Budget overview cards
     st.subheader("Budget Overview")
-    
+
     # Calculate totals
     df_expenses = pd.DataFrame(st.session_state.expenses)
     if not df_expenses.empty:
@@ -85,13 +85,13 @@ def main():
         spent_by_category = current_month_expenses.groupby('category')['amount'].sum().to_dict()
     else:
         spent_by_category = {}
-    
+
     total_budget = sum(st.session_state.budget.values())
     total_spent = sum(spent_by_category.values())
     remaining = total_budget - total_spent
-    
+
     col1, col2, col3 = st.columns(3)
-    
+
     with col1:
         st.markdown(f"""
         <div class="metric-card">
@@ -102,7 +102,7 @@ def main():
             </div>
         </div>
         """, unsafe_allow_html=True)
-    
+
     with col2:
         st.markdown(f"""
         <div class="metric-card">
@@ -115,7 +115,7 @@ def main():
             </div>
         </div>
         """, unsafe_allow_html=True)
-    
+
     with col3:
         st.markdown(f"""
         <div class="metric-card">
@@ -128,82 +128,83 @@ def main():
             </div>
         </div>
         """, unsafe_allow_html=True)
-    
+
     # Two columns layout
     col1, col2 = st.columns([1, 1])
-    
+
     with col1:
-        # Add expense form
-        st.subheader("Add New Expense")
-        
-        with st.form("expense_form"):
-            date = st.date_input("Date", datetime.now())
-            category = st.selectbox("Category", list(st.session_state.budget.keys()))
-            amount = st.number_input(f"Amount ({currency_symbol})", min_value=0.01, step=0.01)
-            description = st.text_input("Description")
-            
-            if st.form_submit_button("Add Expense", use_container_width=True):
-                new_expense = {
-                    "date": date.strftime("%Y-%m-%d"),
-                    "category": category,
-                    "amount": float(amount),
-                    "description": description
-                }
-                st.session_state.expenses.append(new_expense)
-                st.success("Expense added successfully!")
-                st.rerun()
-    
+        with st.expander("Add New Expense", expanded=False):
+            st.subheader("Add New Expense")
+
+            with st.form("expense_form"):
+                date = st.date_input("Date", datetime.now())
+                category = st.selectbox("Category", list(st.session_state.budget.keys()))
+                amount = st.number_input(f"Amount ({currency_symbol})", min_value=0.01, step=0.01)
+                description = st.text_input("Description")
+
+                if st.form_submit_button("Add Expense", use_container_width=True):
+                    new_expense = {
+                        "date": date.strftime("%Y-%m-%d"),
+                        "category": category,
+                        "amount": float(amount),
+                        "description": description
+                    }
+                    st.session_state.expenses.append(new_expense)
+                    st.success("Expense added successfully!")
+                    st.rerun()
+
     with col2:
-        # Budget management
-        st.subheader("Manage Budget")
-        
-        with st.form("budget_form"):
-            st.markdown("Update your monthly budget allocations:")
-            
-            new_budget = {}
-            for category, current_amount in st.session_state.budget.items():
-                new_budget[category] = st.number_input(
-                    f"{category} ({currency_symbol})",
-                    min_value=0.0, 
-                    value=float(current_amount),
-                    step=10.0
-                )
-            
-            if st.form_submit_button("Update Budget", use_container_width=True):
-                st.session_state.budget = new_budget
-                st.success("Budget updated successfully!")
-                st.rerun()
-    
+        with st.expander("Manage Budget", expanded=False):
+            st.subheader("Manage Budget")
+
+            with st.form("budget_form"):
+                st.markdown("Update your monthly budget allocations:")
+
+                new_budget = {}
+                for category, current_amount in st.session_state.budget.items():
+                    new_budget[category] = st.number_input(
+                        f"{category} ({currency_symbol})",
+                        min_value=0.0,
+                        value=float(current_amount),
+                        step=10.0
+                    )
+
+                if st.form_submit_button("Update Budget", use_container_width=True):
+                    st.session_state.budget = new_budget
+                    st.success("Budget updated successfully!")
+                    st.rerun()
+
     # Category breakdown
     if not df_expenses.empty:
-        st.subheader("Category Breakdown")
-        
-        # Create category cards
-        categories = list(st.session_state.budget.keys())
-        cols = st.columns(len(categories))
-        
-        for i, category in enumerate(categories):
-            with cols[i]:
-                spent = spent_by_category.get(category, 0)
-                budget = st.session_state.budget[category]
-                percentage = (spent / budget * 100) if budget > 0 else 0
-                
-                status = "positive" if percentage <= 80 else "negative" if percentage > 100 else "neutral"
-                
-                st.markdown(f"""
-                <div class="category-card">
-                    <h4>{category}</h4>
-                      <div class="category-amount">{format_currency(spent)} / {format_currency(budget)}</div>
-                    <div class="progress-bar">
-                        <div class="progress-fill {status}" style="width: {min(percentage, 100):.1f}%"></div>
+        with st.expander("Category Breakdown", expanded=False):
+            st.subheader("Category Breakdown")
+
+            # Create category cards
+            categories = list(st.session_state.budget.keys())
+            cols = st.columns(len(categories))
+
+            for i, category in enumerate(categories):
+                with cols[i]:
+                    spent = spent_by_category.get(category, 0)
+                    budget = st.session_state.budget[category]
+                    percentage = (spent / budget * 100) if budget > 0 else 0
+
+                    status = "positive" if percentage <= 80 else "negative" if percentage > 100 else "neutral"
+
+                    st.markdown(f"""
+                    <div class="category-card">
+                        <h4>{category}</h4>
+                          <div class="category-amount">{format_currency(spent)} / {format_currency(budget)}</div>
+                        <div class="progress-bar">
+                            <div class="progress-fill {status}" style="width: {min(percentage, 100):.1f}%"></div>
+                        </div>
+                        <div class="category-percentage">{percentage:.1f}% used</div>
                     </div>
-                    <div class="category-percentage">{percentage:.1f}% used</div>
-                </div>
-                """, unsafe_allow_html=True)
-        
+                    """, unsafe_allow_html=True)
+
         # Charts
         col1, col2 = st.columns(2)
-        
+
         with col1:
             st.subheader("Spending by Category")
             if spent_by_category:
@@ -218,15 +219,15 @@ def main():
                     height=400
                 )
                 st.plotly_chart(fig_pie, use_container_width=True)
-        
+
         with col2:
             st.subheader("Monthly Spending Trend")
             daily_spending = current_month_expenses.groupby('date')['amount'].sum().reset_index()
-            
+
             if not daily_spending.empty:
                 fig_line = px.line(
-                    daily_spending,
-                    x='date',
+                daily_spending,
+                x='date',
                     y='amount',
                     title='Daily Spending This Month'
                 )
@@ -237,31 +238,32 @@ def main():
                     yaxis_title="Amount"
                 )
                 st.plotly_chart(fig_line, use_container_width=True)
-    
+
     # Recent transactions
-    st.subheader("Recent Transactions")
-    
-    if df_expenses.empty:
-        st.info("No expenses recorded yet. Add your first expense above!")
-    else:
-        # Display recent transactions
-        recent_expenses = sorted(st.session_state.expenses, key=lambda x: x['date'], reverse=True)[:10]
-        
-        for expense in recent_expenses:
-            st.markdown(f"""
-            <div class="transaction-item">
-                <div class="transaction-content">
-                    <div class="transaction-main">
-                        <span class="transaction-description">{expense['description']}</span>
-                        <span class="transaction-category">{expense['category']}</span>
-                    </div>
-                    <div class="transaction-details">
-                        <span class="transaction-date">{expense['date']}</span>
-                        <span class="transaction-amount">{format_currency(expense['amount'])}</span>
+    with st.expander("Recent Transactions", expanded=False):
+        st.subheader("Recent Transactions")
+
+        if df_expenses.empty:
+            st.info("No expenses recorded yet. Add your first expense above!")
+        else:
+            # Display recent transactions
+            recent_expenses = sorted(st.session_state.expenses, key=lambda x: x['date'], reverse=True)[:10]
+
+            for expense in recent_expenses:
+                st.markdown(f"""
+                <div class="transaction-item">
+                    <div class="transaction-content">
+                        <div class="transaction-main">
+                            <span class="transaction-description">{expense['description']}</span>
+                            <span class="transaction-category">{expense['category']}</span>
+                        </div>
+                        <div class="transaction-details">
+                            <span class="transaction-date">{expense['date']}</span>
+                            <span class="transaction-amount">{format_currency(expense['amount'])}</span>
+                        </div>
                     </div>
                 </div>
-            </div>
-            """, unsafe_allow_html=True)
+                """, unsafe_allow_html=True)
 
 # Execute the page logic
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- group new expense form into a collapsed `st.expander`
- wrap budget management section with an expander
- enclose category charts in an expander
- add expander for recent transactions

## Testing
- `python3 -m py_compile src/pages/Expense_Tracker.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841b41f158c832b99a342da12618aaf