### PR TITLE
Add reusable sidebar helper

### DIFF
--- a/src/pages/Community.py
+++ b/src/pages/Community.py
@@ -1,6 +1,6 @@
 import streamlit as st
 from datetime import datetime, timedelta
-from utils import load_css, check_authentication
+from utils import load_css, check_authentication, render_sidebar
 
 # Page configuration
 st.set_page_config(page_title="Community", page_icon="💬", layout="wide")
@@ -11,21 +11,7 @@ load_css()
 # Check authentication
 check_authentication()
 
-if st.session_state.get("logged_in", False):
-    with st.sidebar:
-        st.header("Navigation")
-        if st.button("Dashboard"):
-            st.switch_page("streamlit_app.py")
-        if st.button("Expense Tracker"):
-            st.switch_page("pages/Expense_Tracker.py")
-        if st.button("Expense Calculator"):
-            st.switch_page("pages/Expense_Calculator.py")
-        if st.button("Visa Planner"):
-            st.switch_page("pages/Visa_Planner.py")
-        if st.button("Community"):
-            st.switch_page("pages/Community.py")
-        if st.button("Job Board"):
-            st.switch_page("pages/Job_Board.py")
+render_sidebar()
 
 # Initialize community data
 if 'community_posts' not in st.session_state:

--- a/src/pages/Expense_Calculator.py
+++ b/src/pages/Expense_Calculator.py
@@ -1,7 +1,7 @@
 import streamlit as st
 import plotly.express as px
 import plotly.graph_objects as go
-from utils import load_css, check_authentication, format_currency, get_country_info
+from utils import load_css, check_authentication, format_currency, get_country_info, render_sidebar
 
 # Page configuration
 st.set_page_config(page_title="Expense Calculator", page_icon="🧮", layout="wide")
@@ -12,21 +12,7 @@ load_css()
 # Check authentication
 check_authentication()
 
-if st.session_state.get("logged_in", False):
-    with st.sidebar:
-        st.header("Navigation")
-        if st.button("Dashboard"):
-            st.switch_page("streamlit_app.py")
-        if st.button("Expense Tracker"):
-            st.switch_page("pages/Expense_Tracker.py")
-        if st.button("Expense Calculator"):
-            st.switch_page("pages/Expense_Calculator.py")
-        if st.button("Visa Planner"):
-            st.switch_page("pages/Visa_Planner.py")
-        if st.button("Community"):
-            st.switch_page("pages/Community.py")
-        if st.button("Job Board"):
-            st.switch_page("pages/Job_Board.py")
+render_sidebar()
 
 # Cost data by country and lifestyle
 COST_DATA = {

--- a/src/pages/Expense_Tracker.py
+++ b/src/pages/Expense_Tracker.py
@@ -3,7 +3,7 @@ import pandas as pd
 import plotly.express as px
 import plotly.graph_objects as go
 from datetime import datetime, timedelta
-from utils import load_css, check_authentication, format_currency, get_country_info
+from utils import load_css, check_authentication, format_currency, get_country_info, render_sidebar
 
 # Page configuration
 st.set_page_config(page_title="Expense Tracker", page_icon="💰", layout="wide")
@@ -14,21 +14,7 @@ load_css()
 # Check authentication
 check_authentication()
 
-if st.session_state.get("logged_in", False):
-    with st.sidebar:
-        st.header("Navigation")
-        if st.button("Dashboard"):
-            st.switch_page("streamlit_app.py")
-        if st.button("Expense Tracker"):
-            st.switch_page("pages/Expense_Tracker.py")
-        if st.button("Expense Calculator"):
-            st.switch_page("pages/Expense_Calculator.py")
-        if st.button("Visa Planner"):
-            st.switch_page("pages/Visa_Planner.py")
-        if st.button("Community"):
-            st.switch_page("pages/Community.py")
-        if st.button("Job Board"):
-            st.switch_page("pages/Job_Board.py")
+render_sidebar()
 
 country_info = get_country_info()
 currency_symbol = country_info[st.session_state.selected_country]['symbol']

--- a/src/pages/Job_Board.py
+++ b/src/pages/Job_Board.py
@@ -1,6 +1,6 @@
 import streamlit as st
 from datetime import datetime, timedelta
-from utils import load_css, check_authentication, get_country_info
+from utils import load_css, check_authentication, get_country_info, render_sidebar
 
 # Page configuration
 st.set_page_config(page_title="Job Board", page_icon="💼", layout="wide")
@@ -11,21 +11,7 @@ load_css()
 # Check authentication
 check_authentication()
 
-if st.session_state.get("logged_in", False):
-    with st.sidebar:
-        st.header("Navigation")
-        if st.button("Dashboard"):
-            st.switch_page("streamlit_app.py")
-        if st.button("Expense Tracker"):
-            st.switch_page("pages/Expense_Tracker.py")
-        if st.button("Expense Calculator"):
-            st.switch_page("pages/Expense_Calculator.py")
-        if st.button("Visa Planner"):
-            st.switch_page("pages/Visa_Planner.py")
-        if st.button("Community"):
-            st.switch_page("pages/Community.py")
-        if st.button("Job Board"):
-            st.switch_page("pages/Job_Board.py")
+render_sidebar()
 
 country_info = get_country_info()
 currency_symbol = country_info[st.session_state.selected_country]['symbol']

--- a/src/pages/Visa_Planner.py
+++ b/src/pages/Visa_Planner.py
@@ -1,7 +1,7 @@
 import streamlit as st
 import pandas as pd
 from datetime import datetime, timedelta
-from utils import load_css, check_authentication, format_currency, get_country_info, get_housing_options
+from utils import load_css, check_authentication, format_currency, get_country_info, get_housing_options, render_sidebar
 
 # Page configuration
 st.set_page_config(page_title="Visa Planner", page_icon="📋", layout="wide")
@@ -12,21 +12,7 @@ load_css()
 # Check authentication
 check_authentication()
 
-if st.session_state.get("logged_in", False):
-    with st.sidebar:
-        st.header("Navigation")
-        if st.button("Dashboard"):
-            st.switch_page("streamlit_app.py")
-        if st.button("Expense Tracker"):
-            st.switch_page("pages/Expense_Tracker.py")
-        if st.button("Expense Calculator"):
-            st.switch_page("pages/Expense_Calculator.py")
-        if st.button("Visa Planner"):
-            st.switch_page("pages/Visa_Planner.py")
-        if st.button("Community"):
-            st.switch_page("pages/Community.py")
-        if st.button("Job Board"):
-            st.switch_page("pages/Job_Board.py")
+render_sidebar()
 
 # Initialize visa data
 if 'visa_documents' not in st.session_state:

--- a/src/utils.py
+++ b/src/utils.py
@@ -344,3 +344,35 @@ def restore_backup_data(backup_data):
     """Restore data from backup"""
     for key, value in backup_data.items():
         st.session_state[key] = value
+
+def render_sidebar():
+    """Render sidebar navigation and quick actions."""
+    if not st.session_state.get("logged_in", False):
+        return
+
+    with st.sidebar:
+        st.header("Navigation")
+        navigation = [
+            ("Dashboard", "streamlit_app.py"),
+            ("Expense Tracker", "pages/Expense_Tracker.py"),
+            ("Expense Calculator", "pages/Expense_Calculator.py"),
+            ("Visa Planner", "pages/Visa_Planner.py"),
+            ("Community", "pages/Community.py"),
+            ("Job Board", "pages/Job_Board.py"),
+        ]
+
+        for label, path in navigation:
+            if st.button(label):
+                st.switch_page(path)
+
+        st.markdown("---")
+        st.header("Quick Actions")
+        if st.button("Add Expense", key="qa_expense"):
+            st.switch_page("pages/Expense_Tracker.py")
+
+        if st.button("Create Post", key="qa_post"):
+            st.session_state.show_create_post = True
+            st.switch_page("pages/Community.py")
+
+        if st.button("Add Job Application", key="qa_job"):
+            st.switch_page("pages/Job_Board.py")


### PR DESCRIPTION
## Summary
- add `render_sidebar` helper in `utils.py`
- use helper in Expense Tracker, Expense Calculator, Visa Planner, Community and Job Board pages

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6841b420c5fc832baf450b2d2cf721f7