### PR TITLE
Improve layout spacing on Expense Tracker and Job Board

### DIFF
--- a/src/pages/Expense_Tracker.py
+++ b/src/pages/Expense_Tracker.py
@@ -128,7 +128,9 @@ def main():
 
     if remaining > 0 and suggestion:
         st.info(f"With your savings, you could afford {suggestion}.")
-    
+
+    st.markdown("---")
+
     # Two columns layout
     col1, col2 = st.columns([1, 1])
 
@@ -171,8 +173,9 @@ def main():
                     st.json(new_budget)
                     st.success("Budget updated successfully!")
                     st.rerun()
-    
-    
+
+    st.markdown("---")
+
     if not df_expenses.empty:
         with st.expander("Category Breakdown", expanded=False):
             categories = list(st.session_state.budget.keys())
@@ -216,7 +219,9 @@ def main():
                     )
                     fig_line.update_layout(font=dict(size=12), height=400, xaxis_title="Date", yaxis_title="Amount")
                     st.plotly_chart(fig_line, use_container_width=True)
-    
+
+    st.markdown("---")
+
     # Recent transactions
     with st.expander("Recent Transactions", expanded=False):
         if df_expenses.empty:

--- a/src/pages/Job_Board.py
+++ b/src/pages/Job_Board.py
@@ -182,7 +182,9 @@ def main():
             </div>
         </div>
         """, unsafe_allow_html=True)
-    
+
+    st.markdown("---")
+
     # Filters
     st.subheader("🔍 Filter Jobs")
     
@@ -226,7 +228,9 @@ def main():
         )
     elif sort_by == "Deadline":
         filtered_jobs = sorted(filtered_jobs, key=lambda x: x['deadline'])
-    
+
+    st.markdown("---")
+
     # Job listings
     st.subheader(f"📋 Job Listings ({len(filtered_jobs)} found)")
     
@@ -259,14 +263,18 @@ def main():
                         st.session_state.job_applications.append(application)
                         st.success("Application submitted successfully!")
                         st.rerun()
-    
+
+    st.markdown("---")
+
     # My Applications section
     if st.session_state.job_applications:
         st.subheader("📋 My Applications")
         
         for app in st.session_state.job_applications:
             st.write(f"{app['job_title']} at {app['company']} - {app['status']} (Applied: {app['applied_date']})")
-    
+
+    st.markdown("---")
+
     # Job search tips
     st.subheader("💡 Job Search Tips for International Students")
     
@@ -287,7 +295,9 @@ def main():
             <span class="tip-text">{tip}</span>
         </div>
         """, unsafe_allow_html=True)
-    
+
+    st.markdown("---")
+
     # Work authorization info
     st.subheader("📋 Work Authorization Quick Guide")
     


### PR DESCRIPTION
## Summary
- insert `st.markdown("---")` between major sections on Expense Tracker
- insert `st.markdown("---")` to create space in Job Board page

## Testing
- `python -m py_compile src/pages/Expense_Tracker.py src/pages/Job_Board.py`

------
https://chatgpt.com/codex/tasks/task_e_6841c66126b0832b9c2fed488bba049f