### PR TITLE
Add voice assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,14 @@ Edit `/src/streamlit_app.py` to customize this app to your heart's desire. :hear
 
 If you have any questions, checkout our [documentation](https://docs.streamlit.io) and [community
 forums](https://discuss.streamlit.io).
+
+## Voice Assistant
+
+The app includes a simple voice assistant powered by the OpenAI API. Navigate to
+**Voice Assistant** from the sidebar or dashboard to start a conversation. You
+will need a valid OpenAI API key for generating responses.
+
+1. Enter your API key when prompted.
+2. Click **Start Listening** to record your question.
+3. After processing, play back the synthesized answer with the **Play Response**
+   button.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 pandas
 streamlit
 plotly
+SpeechRecognition
+gTTS
+openai

--- a/src/pages/Voice_Assistant.py
+++ b/src/pages/Voice_Assistant.py
@@ -1,0 +1,64 @@
+import streamlit as st
+
+from utils import load_css, check_authentication, render_sidebar
+from voice_assistant import (
+    record_audio,
+    transcribe_audio,
+    generate_response,
+    text_to_speech,
+)
+
+st.set_page_config(page_title="Voice Assistant", page_icon="🎙️", layout="wide")
+
+load_css()
+check_authentication()
+
+if st.session_state.get("logged_in", False):
+    render_sidebar()
+
+st.markdown(
+    """
+    <div class="breadcrumb">
+        <span>🎓 StudyAbroad Platform</span> > <span>Voice Assistant</span>
+    </div>
+    """,
+    unsafe_allow_html=True,
+)
+
+st.title("🎙️ Voice Assistant")
+st.markdown("Talk to the assistant for quick answers to your questions.")
+
+if "conversation" not in st.session_state:
+    st.session_state.conversation = []
+
+api_key = st.session_state.get("openai_key", st.secrets.get("OPENAI_API_KEY"))
+api_key_input = st.text_input(
+    "OpenAI API Key", type="password", value=api_key or "", help="Required for generating responses."
+)
+if api_key_input:
+    st.session_state.openai_key = api_key_input
+
+if st.button("Start Listening", use_container_width=True):
+    with st.spinner("Listening..."):
+        try:
+            audio_data = record_audio()
+            text = transcribe_audio(audio_data)
+        except Exception as e:
+            text = ""
+            st.error(f"Error capturing audio: {e}")
+    if text:
+        st.session_state.conversation.append({"speaker": "You", "text": text})
+        response = generate_response(text, api_key=st.session_state.get("openai_key"))
+        audio_bytes = text_to_speech(response)
+        st.session_state.conversation.append({"speaker": "Assistant", "text": response, "audio": audio_bytes})
+    else:
+        st.warning("Could not understand audio.")
+
+st.markdown("---")
+
+st.subheader("Conversation")
+for i, msg in enumerate(st.session_state.conversation):
+    st.markdown(f"**{msg['speaker']}:** {msg['text']}")
+    if msg["speaker"] == "Assistant" and msg.get("audio"):
+        if st.button("Play Response", key=f"play_{i}"):
+            st.audio(msg["audio"].getvalue(), format="audio/mp3")

--- a/src/streamlit_app.py
+++ b/src/streamlit_app.py
@@ -288,7 +288,7 @@ def dashboard():
     st.markdown("Click on any feature to get started with your study abroad journey")
     
     # Feature buttons with navigation
-    col1, col2, col3 = st.columns(3)
+    col1, col2, col3, col4 = st.columns(4)
     
     with col1:
         if st.button("💰 Expense Tracker", key="expense_btn", use_container_width=True, type="primary"):
@@ -357,7 +357,22 @@ def dashboard():
             <p>✓ Work authorization help</p>
         </div>
         """, unsafe_allow_html=True)
-        
+
+
+    with col4:
+        if st.button("🎙️ Voice Assistant", key="assistant_btn", use_container_width=True, type="primary"):
+            st.switch_page("pages/Voice_Assistant.py")
+
+        st.markdown("""
+        <div class="feature-preview">
+            <h4>Ask Anything</h4>
+            <p>✓ Voice commands</p>
+            <p>✓ AI-powered responses</p>
+            <p>✓ Text-to-speech output</p>
+            <p>✓ Conversation history</p>
+        </div>
+        """, unsafe_allow_html=True)
+
         # Achievement badge
         st.markdown("""
         <div class="achievement-badge">

--- a/src/utils.py
+++ b/src/utils.py
@@ -355,9 +355,11 @@ def render_sidebar():
         st.page_link("pages/Visa_Planner.py", label="Visa Planner")
         st.page_link("pages/Community.py", label="Community")
         st.page_link("pages/Job_Board.py", label="Job Board")
+        st.page_link("pages/Voice_Assistant.py", label="Voice Assistant")
 
         st.markdown("---")
         st.header("Quick Actions")
         st.page_link("pages/Expense_Tracker.py", label="Add Expense")
         st.page_link("pages/Community.py", label="Create Post")
         st.page_link("pages/Job_Board.py", label="Apply for Job")
+        st.page_link("pages/Voice_Assistant.py", label="Ask Assistant")

--- a/src/voice_assistant.py
+++ b/src/voice_assistant.py
@@ -1,0 +1,48 @@
+import io
+from typing import Optional
+
+import speech_recognition as sr
+from gtts import gTTS
+import openai
+
+
+def record_audio(timeout: int = 5, phrase_time_limit: int = 10) -> sr.AudioData:
+    """Record audio from the default microphone."""
+    recognizer = sr.Recognizer()
+    with sr.Microphone() as source:
+        audio = recognizer.listen(source, timeout=timeout, phrase_time_limit=phrase_time_limit)
+    return audio
+
+
+def transcribe_audio(audio: sr.AudioData) -> str:
+    """Convert recorded audio to text using Google's free API."""
+    recognizer = sr.Recognizer()
+    try:
+        return recognizer.recognize_google(audio)
+    except sr.UnknownValueError:
+        return ""
+    except sr.RequestError:
+        return ""
+
+
+def generate_response(prompt: str, api_key: Optional[str] = None, model: str = "gpt-3.5-turbo") -> str:
+    """Generate a response using the OpenAI API."""
+    if api_key:
+        openai.api_key = api_key
+    try:
+        response = openai.ChatCompletion.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}]
+        )
+        return response.choices[0].message["content"].strip()
+    except Exception as e:
+        return f"Error: {e}"
+
+
+def text_to_speech(text: str) -> io.BytesIO:
+    """Convert text to speech and return audio bytes."""
+    tts = gTTS(text)
+    audio_bytes = io.BytesIO()
+    tts.write_to_fp(audio_bytes)
+    audio_bytes.seek(0)
+    return audio_bytes


### PR DESCRIPTION
## Summary
- add packages for speech recognition, TTS and OpenAI integration
- implement `voice_assistant.py` with basic speech-to-text and text-to-speech helpers
- create a new Streamlit page to interact with the assistant
- add navigation links and dashboard button
- document the new feature in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6841e5bb712c832b897cae46524d932a