### PR TITLE
Enhance voice assistant with budget context

### DIFF
--- a/src/voice_assistant.py
+++ b/src/voice_assistant.py
@@ -25,8 +25,30 @@ def transcribe_audio(audio: sr.AudioData) -> str:
         return ""
 
 
-def generate_response(prompt: str, api_key: Optional[str] = None, model: str = "gemini-pro") -> str:
-    """Generate a response using the Gemini API."""
+def generate_response(
+    prompt: str,
+    api_key: Optional[str] = None,
+    model: str = "gemini-pro",
+    context: Optional[str] = None,
+) -> str:
+    """Generate a response using the Gemini API.
+
+    Parameters
+    ----------
+    prompt: str
+        The user's prompt.
+    api_key: Optional[str]
+        API key for Gemini. If provided, it overrides environment configuration.
+    model: str
+        Gemini model name.
+    context: Optional[str]
+        Additional context prepended to the prompt to help the model generate
+        informed answers.
+    """
+
+    if context:
+        prompt = f"{context}\n{prompt}"
+
     if api_key:
         genai.configure(api_key=api_key)
     try:


### PR DESCRIPTION
## Summary
- allow `generate_response` to accept optional context that is prepended to prompts
- gather budget and expense summary on the Voice Assistant page
- pass the summary to `generate_response` so Gemini has budget info

## Testing
- `python -m py_compile src/voice_assistant.py src/pages/Voice_Assistant.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68425eae7e10832bb26c651b9ac3d25e