### PR TITLE
Install PyAudio support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y \
     curl \
     software-properties-common \
     git \
+    portaudio19-dev \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt ./

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ plotly
 SpeechRecognition
 gTTS
 google-generativeai
+pyaudio


### PR DESCRIPTION
## Summary
- install system library `portaudio19-dev` so PyAudio can compile
- include `pyaudio` python package

## Testing
- `pip install pyaudio` *(fails: Tunnel connection failed)*
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*


------
https://chatgpt.com/codex/tasks/task_e_684264413ee8832b9eabd036a33aa2cf