### PR TITLE
Remove pandas import from Voice Assistant

### DIFF
--- a/src/pages/Voice_Assistant.py
+++ b/src/pages/Voice_Assistant.py
@@ -1,6 +1,5 @@
 import streamlit as st
 import os
-import pandas as pd
 
 from utils import load_css, check_authentication, render_sidebar, format_currency
 from voice_assistant import (


### PR DESCRIPTION
## Summary
- clean up unused import from Voice_Assistant.py

## Testing
- `python -m py_compile src/pages/Voice_Assistant.py`

------
https://chatgpt.com/codex/tasks/task_e_684265441c40832ba0020b51aed14c88