### PR TITLE
Handle missing microphone in voice assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ will need a valid Gemini API key for generating responses. Install the
 client.
 
 1. Enter your API key when prompted.
-2. Click **Start Listening** to record your question.
-3. After processing, play back the synthesized answer with the **Play Response**
+2. Ensure your device has a working microphone configured as the default input device.
+3. Click **Start Listening** to record your question.
+4. After processing, play back the synthesized answer with the **Play Response**
    button.

--- a/src/pages/Voice_Assistant.py
+++ b/src/pages/Voice_Assistant.py
@@ -1,6 +1,5 @@
 import streamlit as st
 import os
-import pandas as pd
 
 from utils import load_css, check_authentication, render_sidebar, format_currency
 from voice_assistant import (
@@ -68,6 +67,8 @@ if st.button("Start Listening", use_container_width=True):
         except Exception as e:
             text = ""
             st.error(f"Error capturing audio: {e}")
+            if "No default input device" in str(e):
+                st.info("Please connect a microphone and ensure it is set as the default input device.")
     if text:
         st.session_state.conversation.append({"speaker": "You", "text": text})
         response = generate_response(text, api_key=st.session_state.get("gemini_key"), context=context)

--- a/src/voice_assistant.py
+++ b/src/voice_assistant.py
@@ -7,11 +7,22 @@ import google.generativeai as genai
 
 
 def record_audio(timeout: int = 5, phrase_time_limit: int = 10) -> sr.AudioData:
-    """Record audio from the default microphone."""
+    """Record audio from the default microphone.
+
+    Raises
+    ------
+    RuntimeError
+        If no default input device is available.
+    """
     recognizer = sr.Recognizer()
-    with sr.Microphone() as source:
-        audio = recognizer.listen(source, timeout=timeout, phrase_time_limit=phrase_time_limit)
-    return audio
+    try:
+        if not sr.Microphone.list_microphone_names():
+            raise RuntimeError("No default input device available")
+        with sr.Microphone() as source:
+            audio = recognizer.listen(source, timeout=timeout, phrase_time_limit=phrase_time_limit)
+        return audio
+    except OSError as e:
+        raise RuntimeError("No default input device available") from e
 
 
 def transcribe_audio(audio: sr.AudioData) -> str:


### PR DESCRIPTION
## Summary
- handle the absence of a default input device when recording audio
- display hint on Voice Assistant page when no microphone is found
- document microphone requirement in README

## Testing
- `python -m py_compile src/pages/Voice_Assistant.py src/voice_assistant.py`


------
https://chatgpt.com/codex/tasks/task_e_684265441c40832ba0020b51aed14c88