### PR TITLE
Add local run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,21 @@ client.
 3. Click **Start Listening** to record your question.
 4. After processing, play back the synthesized answer with the **Play Response**
    button.
+
+## Running Locally
+
+Install the dependencies and launch the Streamlit app on your machine:
+
+```bash
+pip install -r requirements.txt
+streamlit run src/streamlit_app.py
+```
+
+Alternatively you can use Docker:
+
+```bash
+docker build -t designthinking .
+docker run -p 8501:8501 designthinking
+```
+
+The Voice Assistant requires access to a microphone.


### PR DESCRIPTION
## Summary
- document how to run the Streamlit app locally
- mention optional Docker commands
- remind users that the Voice Assistant needs a microphone

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68426b578db4832b9e532cf853b71a1f