### PR TITLE
Handle Gemini API errors

### DIFF
--- a/src/pages/Voice_Assistant.py
+++ b/src/pages/Voice_Assistant.py
@@ -7,6 +7,7 @@ from voice_assistant import (
     transcribe_audio,
     generate_response,
     text_to_speech,
+    ResponseGenerationError,
 )
 
 st.set_page_config(page_title="Voice Assistant", page_icon="🎙️", layout="wide")
@@ -71,9 +72,21 @@ if st.button("Start Listening", use_container_width=True):
                 st.info("Please connect a microphone and ensure it is set as the default input device.")
     if text:
         st.session_state.conversation.append({"speaker": "You", "text": text})
-        response = generate_response(text, api_key=st.session_state.get("gemini_key"), context=context)
-        audio_bytes = text_to_speech(response)
-        st.session_state.conversation.append({"speaker": "Assistant", "text": response, "audio": audio_bytes})
+        try:
+            response = generate_response(
+                text,
+                api_key=st.session_state.get("gemini_key"),
+                context=context,
+            )
+        except ResponseGenerationError as e:
+            st.error(f"Error generating response: {e}")
+            response = None
+
+        if response:
+            audio_bytes = text_to_speech(response)
+            st.session_state.conversation.append(
+                {"speaker": "Assistant", "text": response, "audio": audio_bytes}
+            )
     else:
         st.warning("Could not understand audio.")
 

--- a/src/voice_assistant.py
+++ b/src/voice_assistant.py
@@ -6,6 +6,10 @@ from gtts import gTTS
 import google.generativeai as genai
 
 
+class ResponseGenerationError(Exception):
+    """Raised when the Gemini API fails to generate a response."""
+
+
 def record_audio(timeout: int = 5, phrase_time_limit: int = 10) -> sr.AudioData:
     """Record audio from the default microphone.
 
@@ -67,7 +71,7 @@ def generate_response(
         response = model.generate_content(prompt)
         return response.text
     except Exception as e:
-        return f"Error: {e}"
+        raise ResponseGenerationError(str(e))
 
 
 def text_to_speech(text: str) -> io.BytesIO:


### PR DESCRIPTION
## Summary
- add `ResponseGenerationError` exception and raise it if API call fails
- catch response errors in Voice Assistant page and show `st.error`

## Testing
- `python3 -m py_compile src/voice_assistant.py src/pages/Voice_Assistant.py`

------
https://chatgpt.com/codex/tasks/task_e_6842932e8804832b9a235d811f4e226b