### PR TITLE
Remove YAML front matter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,6 @@
----
-title: DesignThinking
-emoji: 🚀
-colorFrom: red
-colorTo: red
-sdk: docker
-app_port: 8501
-tags:
-- streamlit
-pinned: false
-short_description: Prototype for Design Thinking group project
----
+# DesignThinking
 
-# Welcome to Streamlit!
+## Welcome to Streamlit!
 
 Edit `/src/streamlit_app.py` to customize this app to your heart's desire. :heart:
 
@@ -54,3 +43,4 @@ docker run -p 8501:8501 designthinking
 ```
 
 The Voice Assistant requires access to a microphone.
+

--- a/docs/metadata.yml
+++ b/docs/metadata.yml
@@ -1,0 +1,10 @@
+title: DesignThinking
+emoji: "\U0001F680"
+colorFrom: red
+colorTo: red
+sdk: docker
+app_port: 8501
+tags:
+  - streamlit
+pinned: false
+short_description: Prototype for Design Thinking group project


### PR DESCRIPTION
## Summary
- remove the YAML front matter from README
- add a docs/metadata.yml file to preserve the metadata
- begin README with project title

## Testing
- `python -m compileall -q src`


------
https://chatgpt.com/codex/tasks/task_e_684293373168832ba4293af4716c024a