### PR TITLE
Add commit message guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing
+
+Thank you for taking the time to contribute to DesignThinking! To keep the project easy to maintain, please follow the guidelines below.
+
+## Development Setup
+
+1. Fork and clone the repository.
+2. Create a virtual environment and install the dependencies listed in `requirements.txt`.
+
+## Commit Messages
+
+Clear commit messages make the project history easy to understand. When committing changes:
+
+- **Summarize changes in the first line** using the imperative mood (e.g. "Add new page layout").
+- Keep the summary under **50 characters** when possible.
+- Separate the summary from additional details with a blank line.
+- Include references to relevant issues in the body if applicable.
+
+Example:
+
+```text
+Add login form validation
+
+The form now checks for empty fields before submission. Fixes #42.
+```
+
+## Pull Requests
+
+1. Create a feature branch for your work.
+2. Ensure your code follows the existing style and passes any tests.
+3. Open a pull request describing your changes.
+
+By following these practices, you help keep the project history readable and collaboration smooth.

--- a/README.md
+++ b/README.md
@@ -54,3 +54,7 @@ docker run -p 8501:8501 designthinking
 ```
 
 The Voice Assistant requires access to a microphone.
+
+## Contributing
+
+We welcome pull requests! Please read our [CONTRIBUTING](CONTRIBUTING.md) guide for instructions. Commit messages should briefly summarize your changes so others can follow the project history with ease.


### PR DESCRIPTION
## Summary
- add CONTRIBUTING with commit message best practices
- encourage short commit summaries in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68429339df8c832b914b422f77fc6c54