### PR TITLE
Improve password security

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,9 @@ docker run -p 8501:8501 designthinking
 ```
 
 The Voice Assistant requires access to a microphone.
+
+## Authentication Update
+
+Passwords are now stored using `bcrypt` via the `passlib` library. Any existing
+accounts created with the old SHA-256 scheme will no longer work. Recreate your
+demo accounts after upgrading the dependencies.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ SpeechRecognition
 gTTS
 google-generativeai==0.4.1
 pyaudio
+passlib

--- a/src/users.json
+++ b/src/users.json
@@ -1,6 +1,6 @@
 [
   {
     "username": "student",
-    "password": "264c8c381bf16c982a4e59b0dd4c6f7808c51a05f64c35db42cc78a2a72875bb"
+    "password": "$2b$12$FzgMEziPTGpGQd6MmRGLce8CrdiYFAxb6RJkcKTda0mD.7s4JtaX."
   }
 ]

--- a/src/utils.py
+++ b/src/utils.py
@@ -2,7 +2,7 @@ import streamlit as st
 import os
 from pathlib import Path
 import json
-import hashlib
+from passlib.hash import bcrypt
 
 def load_css():
     """Load custom CSS styles"""
@@ -33,7 +33,7 @@ def register_user(username, password):
     users = load_users()
     if any(u["username"] == username for u in users):
         return False, "Username already exists."
-    hashed = hashlib.sha256(password.encode()).hexdigest()
+    hashed = bcrypt.hash(password)
     users.append({"username": username, "password": hashed})
     save_users(users)
     return True, "Registration successful."
@@ -41,9 +41,8 @@ def register_user(username, password):
 def check_login(username, password):
     """Check login credentials"""
     users = load_users()
-    hashed = hashlib.sha256(password.encode()).hexdigest()
     for user in users:
-        if user["username"] == username and user["password"] == hashed:
+        if user["username"] == username and bcrypt.verify(password, user["password"]):
             return True
     return False
 


### PR DESCRIPTION
## Summary
- use bcrypt via passlib for hashing and verifying passwords
- regenerate demo user with bcrypt hash
- update requirements
- document breaking change

## Testing
- `python -m py_compile src/utils.py src/pages/Register.py src/streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_6842933ba774832b9724cb80d10ff29a